### PR TITLE
Fix domain creation through the API

### DIFF
--- a/lib/NGCP/Panel/Controller/API/Domains.pm
+++ b/lib/NGCP/Panel/Controller/API/Domains.pm
@@ -206,6 +206,8 @@ sub POST :Allow {
             last;
         }
 
+        $guard->commit;
+
         try {
             unless($c->config->{features}->{debug}) {
                 $self->xmpp_domain_reload($c, $resource->{domain});
@@ -222,8 +224,6 @@ sub POST :Allow {
             my ($c) = @_;
             my $_domain = $self->item_by_id($c, $billing_domain->id);
             return $self->hal_from_item($c,$_domain); });
-
-        $guard->commit;
 
         $c->response->status(HTTP_CREATED);
         $c->response->header(Location => sprintf('/%s%d', $c->request->path, $billing_domain->id));


### PR DESCRIPTION
While testing the ngcp-panel and the API we encountered an issue with domain creation through the API. When creating a domain through the API a restart of _kamailio-proxy_ was required. Without a restart _kamailio-proxy_ would refuse connections to the new domain with the following message:

```
Apr 13 15:43:54 voip02-ams3-do proxy[4389]: NOTICE: <script>: New
request on proxy - M=REGISTER R=sip:sub.domain.co
F=sip:username_3217 at sub.domain.co T=sip:username_3217 at sub.domain.co
IP={IP_ADDRESS} (127.0.0.1:5060) ID=b75aa40b-c9aa67f3@{IP_ADDRESS}
Apr 13 15:43:54 voip02-ams3-do proxy[4389]: WARNING: <script>: Domain
not served here - R=sip:sub.domain.co
ID=b75aa40b-c9aa67f3@{IP_ADDRESS}
```

By moving the _$guard->commit;_ to before the code that flushes kamailio-proxy I was able to fix this.

I'm no Perl or ngcp expert so happy to hear any feedback on this.
